### PR TITLE
GBA-753: kit Item needs attributes field in order for rollups to copy…

### DIFF
--- a/greenback-kit-core/src/main/java/com/greenback/kit/model/Item.java
+++ b/greenback-kit-core/src/main/java/com/greenback/kit/model/Item.java
@@ -1,6 +1,7 @@
 package com.greenback.kit.model;
 
 import java.util.List;
+import java.util.Map;
 
 public class Item {
  
@@ -12,6 +13,7 @@ public class Item {
     private Double unitPrice;
     private Double amount;
     private String taxGrn;
+    protected Map<String,String> attributes;
 
     public String getGrn() {
         return grn;
@@ -85,4 +87,11 @@ public class Item {
         return this;
     }
 
+    public Map<String,String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String,String> attributes) {
+        this.attributes = attributes;
+    }
 }


### PR DESCRIPTION
… over item attributes

Note: admin-kit needs the kit version bumped, and lambda needs the admin-kit version bumped